### PR TITLE
Disable cert verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,9 @@ optional arguments:
                         downloads.adblockplus.org/easylist_noadult.txt)
   --cachedir CACHEDIR   Which directory to use for storing cached content
                         (default: .cache)
+  --verify              Verify TLS certificate. The default is to NOT verify
+                        the TLS certificate, as this check is about something
+                        else. Usually this is done with a separated/dedicated
+                        service check
   --verbose             Show found URLs
 ```


### PR DESCRIPTION
Disable TLS certificate verification. This can optionally be renabled by supplying the command line arg `--verify`.

Rationale: TLS certs should ideally be monitored using a dedicated check. Failure on the TLS cert do not belong here in this plugin.